### PR TITLE
Split naming process in rust

### DIFF
--- a/packages/cargo/jns42-generator/src/generators/interiors_rs.rs
+++ b/packages/cargo/jns42-generator/src/generators/interiors_rs.rs
@@ -8,13 +8,20 @@ use std::{collections::HashSet, error::Error};
 
 pub fn generate_file_token_stream(
   specification: &Specification,
+  is_primary: bool,
 ) -> Result<TokenStream, Box<dyn Error>> {
   let mut tokens = quote! {};
 
   for (key, item) in specification.arena.iter().enumerate() {
-    if item.id.is_some() {
-      tokens.append_all(generate_type_token_stream(specification, &key, item));
+    if item.primary.unwrap_or_default() != is_primary {
+      continue;
     }
+
+    if item.id.is_none() {
+      continue;
+    };
+
+    tokens.append_all(generate_type_token_stream(specification, &key, item));
   }
 
   Ok(tokens)

--- a/packages/cargo/jns42-generator/src/generators/interiors_rs.rs
+++ b/packages/cargo/jns42-generator/src/generators/interiors_rs.rs
@@ -34,11 +34,14 @@ fn generate_type_token_stream(
 ) -> Result<TokenStream, Box<dyn Error>> {
   let mut tokens = quote! {};
 
-  let documentation: Vec<_> = [&item.title, &item.description, &item.id]
-    .into_iter()
-    .flatten()
-    .cloned()
-    .collect();
+  let documentation: Vec<_> = [
+    item.title.clone(),
+    item.description.clone(),
+    item.id.as_ref().map(|id| id.get_url().to_string()),
+  ]
+  .into_iter()
+  .flatten()
+  .collect();
   let documentation = documentation.join("\n\n");
 
   tokens.append_all(quote! {

--- a/packages/cargo/jns42-generator/src/generators/package.rs
+++ b/packages/cargo/jns42-generator/src/generators/package.rs
@@ -35,13 +35,21 @@ pub async fn generate_package(
   let content = super::file::generate_file_content(tokens)?;
   fs::write(src_path.join("errors.rs"), content).await?;
 
-  let tokens = super::types_rs::generate_file_token_stream(specification)?;
+  let tokens = super::types_rs::generate_file_token_stream(specification, true)?;
   let content = super::file::generate_file_content(tokens)?;
   fs::write(src_path.join("types.rs"), content).await?;
 
-  let tokens = super::interiors_rs::generate_file_token_stream(specification)?;
+  let tokens = super::interiors_rs::generate_file_token_stream(specification, true)?;
   let content = super::file::generate_file_content(tokens)?;
   fs::write(src_path.join("interiors.rs"), content).await?;
+
+  let tokens = super::types_rs::generate_file_token_stream(specification, false)?;
+  let content = super::file::generate_file_content(tokens)?;
+  fs::write(src_path.join("types_secondary.rs"), content).await?;
+
+  let tokens = super::interiors_rs::generate_file_token_stream(specification, false)?;
+  let content = super::file::generate_file_content(tokens)?;
+  fs::write(src_path.join("interiors_secondary.rs"), content).await?;
 
   Ok(())
 }

--- a/packages/cargo/jns42-generator/src/generators/types_rs.rs
+++ b/packages/cargo/jns42-generator/src/generators/types_rs.rs
@@ -5,13 +5,20 @@ use std::error::Error;
 
 pub fn generate_file_token_stream(
   specification: &Specification,
+  is_primary: bool,
 ) -> Result<TokenStream, Box<dyn Error>> {
   let mut tokens = quote! {};
 
   for (key, item) in specification.arena.iter().enumerate() {
-    if item.id.is_some() {
-      tokens.append_all(generate_type_token_stream(specification, &key, item));
+    if item.primary.unwrap_or_default() != is_primary {
+      continue;
     }
+
+    if item.id.is_none() {
+      continue;
+    };
+
+    tokens.append_all(generate_type_token_stream(specification, &key, item));
   }
 
   Ok(tokens)

--- a/packages/cargo/jns42-generator/src/generators/types_rs.rs
+++ b/packages/cargo/jns42-generator/src/generators/types_rs.rs
@@ -31,11 +31,14 @@ fn generate_type_token_stream(
 ) -> Result<TokenStream, Box<dyn Error>> {
   let mut tokens = quote! {};
 
-  let documentation: Vec<_> = [&item.title, &item.description, &item.id]
-    .into_iter()
-    .flatten()
-    .cloned()
-    .collect();
+  let documentation: Vec<_> = [
+    item.title.clone(),
+    item.description.clone(),
+    item.id.as_ref().map(|id| id.get_url().to_string()),
+  ]
+  .into_iter()
+  .flatten()
+  .collect();
   let documentation = documentation.join("\n\n");
 
   tokens.append_all(quote! {

--- a/packages/cargo/jns42-generator/src/models/schema.rs
+++ b/packages/cargo/jns42-generator/src/models/schema.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, iter::empty};
 
+use crate::utils::url::UrlWithPointer;
+
 use super::intermediate::IntermediateType;
 use serde_json::Value;
 
@@ -38,7 +40,7 @@ impl From<&IntermediateType> for SchemaType {
 pub struct SchemaNode {
   pub primary: Option<bool>,
   pub parent: Option<SchemaKey>,
-  pub id: Option<String>,
+  pub id: Option<UrlWithPointer>,
 
   // metadata
   pub title: Option<String>,

--- a/packages/cargo/jns42-generator/src/models/schema.rs
+++ b/packages/cargo/jns42-generator/src/models/schema.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, iter::empty};
 
 use super::intermediate::IntermediateType;
 use serde_json::Value;
@@ -36,6 +36,7 @@ impl From<&IntermediateType> for SchemaType {
 
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct SchemaNode {
+  pub primary: Option<bool>,
   pub parent: Option<SchemaKey>,
   pub id: Option<String>,
 
@@ -93,4 +94,44 @@ pub struct SchemaNode {
 
   pub minimum_properties: Option<usize>,
   pub maximum_properties: Option<usize>,
+}
+
+impl SchemaNode {
+  pub fn get_children(&self) -> impl Iterator<Item = SchemaKey> + '_ {
+    empty()
+      .chain(self.reference)
+      .chain(self.r#if)
+      .chain(self.then)
+      .chain(self.r#else)
+      .chain(self.not)
+      .chain(self.map_properties)
+      .chain(self.array_items)
+      .chain(self.property_names)
+      .chain(self.contains)
+      .chain(self.tuple_items.iter().flat_map(|v| v.iter().copied()))
+      .chain(self.all_of.iter().flat_map(|v| v.iter().copied()))
+      .chain(self.any_of.iter().flat_map(|v| v.iter().copied()))
+      .chain(self.one_of.iter().flat_map(|v| v.iter().copied()))
+      .chain(
+        self
+          .object_properties
+          .iter()
+          .flat_map(|v| v.values())
+          .copied(),
+      )
+      .chain(
+        self
+          .pattern_properties
+          .iter()
+          .flat_map(|v| v.values())
+          .copied(),
+      )
+      .chain(
+        self
+          .dependent_schemas
+          .iter()
+          .flat_map(|v| v.values())
+          .copied(),
+      )
+  }
 }

--- a/packages/cargo/jns42-generator/src/models/specification.rs
+++ b/packages/cargo/jns42-generator/src/models/specification.rs
@@ -18,7 +18,7 @@ pub struct Specification {
 }
 
 impl Specification {
-  pub fn new(intermediate_document: IntermediateSchema) -> Self {
+  pub fn new(root_id: String, intermediate_document: IntermediateSchema) -> Self {
     let mut parents: HashMap<_, &str> = HashMap::new();
     let mut implicit_types = HashMap::new();
 
@@ -96,7 +96,10 @@ impl Specification {
           .as_ref()
           .map(|url| *key_map.get(schema_url.join(url).unwrap().as_str()).unwrap());
 
+        let primary = if id == root_id { Some(true) } else { None };
+
         let item = SchemaNode {
+          primary,
           parent,
           types,
 
@@ -216,6 +219,18 @@ impl Specification {
       fn transformer(arena: &mut Arena<SchemaNode>, key: usize) {
         schema_transforms::single_type::single_type_transform(arena, key);
         schema_transforms::explode::explode_transform(arena, key);
+      }
+
+      while arena.apply_transform(transformer) > 0 {
+        //
+      }
+    }
+
+    // then set schema primary field
+
+    {
+      fn transformer(arena: &mut Arena<SchemaNode>, key: usize) {
+        schema_transforms::primary::primary_transform(arena, key);
       }
 
       while arena.apply_transform(transformer) > 0 {

--- a/packages/cargo/jns42-generator/src/models/specification.rs
+++ b/packages/cargo/jns42-generator/src/models/specification.rs
@@ -22,27 +22,9 @@ impl Specification {
     let mut parents: HashMap<_, &str> = HashMap::new();
     let mut implicit_types = HashMap::new();
 
-    let urls: Vec<_> = intermediate_document
-      .schemas
-      .keys()
-      .map(|key| UrlWithPointer::parse(key).unwrap())
-      .collect();
-
-    let original_names: Vec<_> = urls
-      .iter()
-      .map(|url| {
-        let name: Vec<_> = url.get_pointer().as_ref().clone();
-        (url, name)
-      })
-      .collect();
-
-    let names = optimize_names(original_names, 5)
-      .into_iter()
-      .map(|(id, name)| (id.clone(), name))
-      .collect();
+    // first load schemas in the arena
 
     let mut arena = Arena::new();
-
     {
       let mut key_map: HashMap<&str, usize> = HashMap::new();
       for (id, schema) in &intermediate_document.schemas {
@@ -228,6 +210,8 @@ impl Specification {
       }
     }
 
+    // then optimize the schemas
+
     {
       fn transformer(arena: &mut Arena<SchemaNode>, key: usize) {
         schema_transforms::single_type::single_type_transform(arena, key);
@@ -238,6 +222,27 @@ impl Specification {
         //
       }
     }
+
+    // generate names
+
+    let urls: Vec<_> = intermediate_document
+      .schemas
+      .keys()
+      .map(|key| UrlWithPointer::parse(key).unwrap())
+      .collect();
+
+    let original_names: Vec<_> = urls
+      .iter()
+      .map(|url| {
+        let name: Vec<_> = url.get_pointer().as_ref().clone();
+        (url, name)
+      })
+      .collect();
+
+    let names = optimize_names(original_names, 5)
+      .into_iter()
+      .map(|(id, name)| (id.clone(), name))
+      .collect();
 
     Self { arena, names }
   }

--- a/packages/cargo/jns42-generator/src/programs/package.rs
+++ b/packages/cargo/jns42-generator/src/programs/package.rs
@@ -84,7 +84,7 @@ pub async fn run_command(options: CommandOptions) -> Result<(), Box<dyn Error>> 
 
   let intermediate_document = context.get_intermediate_document();
 
-  let specification = Specification::new(intermediate_document);
+  let specification = Specification::new(schema_url.to_string(), intermediate_document);
 
   generate_package(
     PackageConfiguration {

--- a/packages/cargo/jns42-generator/src/programs/package.rs
+++ b/packages/cargo/jns42-generator/src/programs/package.rs
@@ -72,19 +72,17 @@ pub async fn run_command(options: CommandOptions) -> Result<(), Box<dyn Error>> 
     Box::new(move |_context, _initializer| Rc::new(draft_04::Document::new())),
   );
 
+  let schema_url = schema_url.clone().into();
   let context = Rc::new(context);
   context
-    .load_from_url(
-      &schema_url.clone().into(),
-      &schema_url.clone().into(),
-      None,
-      &default_meta_schema_url,
-    )
+    .load_from_url(&schema_url, &schema_url, None, &default_meta_schema_url)
     .await;
+
+  let root_url = context.resolve_retrieval_url(&schema_url).unwrap();
 
   let intermediate_document = context.get_intermediate_document();
 
-  let specification = Specification::new(schema_url.to_string(), intermediate_document);
+  let specification = Specification::new(root_url.to_string(), intermediate_document);
 
   generate_package(
     PackageConfiguration {

--- a/packages/cargo/jns42-generator/src/programs/package.rs
+++ b/packages/cargo/jns42-generator/src/programs/package.rs
@@ -82,7 +82,7 @@ pub async fn run_command(options: CommandOptions) -> Result<(), Box<dyn Error>> 
 
   let intermediate_document = context.get_intermediate_document();
 
-  let specification = Specification::new(root_url.to_string(), intermediate_document);
+  let specification = Specification::new(root_url, intermediate_document);
 
   generate_package(
     PackageConfiguration {

--- a/packages/cargo/jns42-generator/src/schema_transforms/explode.rs
+++ b/packages/cargo/jns42-generator/src/schema_transforms/explode.rs
@@ -162,7 +162,7 @@ mod tests {
   use crate::models::{arena::Arena, schema::SchemaNode};
 
   #[test]
-  fn test_explode() {
+  fn test_explode_transform() {
     let mut arena = Arena::new();
 
     arena.add_item(SchemaNode {
@@ -176,7 +176,9 @@ mod tests {
       ..Default::default()
     });
 
-    arena.apply_transform(explode_transform);
+    while arena.apply_transform(explode_transform) > 0 {
+      //
+    }
 
     let actual: Vec<_> = arena.iter().cloned().collect();
     let expected = vec![

--- a/packages/cargo/jns42-generator/src/schema_transforms/mod.rs
+++ b/packages/cargo/jns42-generator/src/schema_transforms/mod.rs
@@ -1,2 +1,3 @@
 pub mod explode;
+pub mod primary;
 pub mod single_type;

--- a/packages/cargo/jns42-generator/src/schema_transforms/primary.rs
+++ b/packages/cargo/jns42-generator/src/schema_transforms/primary.rs
@@ -1,0 +1,94 @@
+use crate::models::{arena::Arena, schema::SchemaNode};
+
+/**
+ * This sets the primary field on all relevant schemas
+ *
+ * ```yaml
+ * - primary: true
+ *   allOf: 1
+ * - {}
+ * ```
+ *
+ * will become
+ *
+ * ```yaml
+ * - primary: true
+ *   allOf: 1
+ * - primary: true
+ * ```
+ */
+pub fn primary_transform(arena: &mut Arena<SchemaNode>, key: usize) {
+  let item = arena.get_item(key);
+
+  let Some(primary) = item.primary else {
+    return;
+  };
+
+  if !primary {
+    return;
+  }
+
+  let item = item.clone();
+
+  // set all children to primary
+  for child_key in item.get_children() {
+    let child_item = arena.get_item(child_key);
+
+    let child_item = SchemaNode {
+      primary: Some(true),
+      ..child_item.clone()
+    };
+
+    arena.set_item(child_key, child_item);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::models::{arena::Arena, schema::SchemaNode};
+
+  #[test]
+  fn test_primary_transform() {
+    let mut arena = Arena::new();
+
+    arena.add_item(SchemaNode {
+      primary: Some(true),
+      all_of: Some(vec![1]),
+      ..Default::default()
+    });
+
+    arena.add_item(SchemaNode {
+      all_of: Some(vec![2]),
+      ..Default::default()
+    });
+
+    arena.add_item(SchemaNode {
+      ..Default::default()
+    });
+
+    while arena.apply_transform(primary_transform) > 0 {
+      //
+    }
+
+    let actual: Vec<_> = arena.iter().cloned().collect();
+    let expected = vec![
+      SchemaNode {
+        primary: Some(true),
+        all_of: Some(vec![1]),
+        ..Default::default()
+      },
+      SchemaNode {
+        primary: Some(true),
+        all_of: Some(vec![2]),
+        ..Default::default()
+      },
+      SchemaNode {
+        primary: Some(true),
+        ..Default::default()
+      },
+    ];
+
+    assert_eq!(actual, expected)
+  }
+}


### PR DESCRIPTION
We split the names in primary and secondary names. And then run then naming process separate for each. So we will have better primary names. The secondary names will probably never be used.

see #64, #71 

- [x] split names in primary and secondary
- [x] run naming process for primary and secondary
- [x] use the primary and secondary names everywhere
- [x] fix urls again
