### PR TITLE
Fix regex check in splitIterableText

### DIFF
--- a/packages/npm/jns42-generator/src/utilities/iterable.ts
+++ b/packages/npm/jns42-generator/src/utilities/iterable.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 export function* joinIterable<T, G>(iterable: Iterable<T>, glue: G): Iterable<T | G> {
   let count = 0;
   for (const item of iterable) {
@@ -15,7 +17,11 @@ export function* mapIterable<T, R>(iterable: Iterable<T>, mapper: (item: T) => R
   }
 }
 
-export function* splitIterableText(texts: Iterable<string>, separator = /\r?\n/): Iterable<string> {
+export function* splitIterableText(
+  texts: Iterable<string>,
+  separator = /\r?\n/,
+): Iterable<string> {
+  assert(!separator.global, "global regexes are not supported");
   let buffer = "";
 
   for (const text of texts) {


### PR DESCRIPTION
## Summary
- assert on regex flags in `splitIterableText`

## Testing
- `npm test --silent` *(no output)*
- `npm --workspace @jns42/generator test --silent` *(fails: just not found)*
- `cargo test --workspace --quiet` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68414dc57208832c8107c9f9f1ca59c1